### PR TITLE
Add H2 setup and product domain entities

### DIFF
--- a/src/main/java/vn/id/thongdanghoang/Category.java
+++ b/src/main/java/vn/id/thongdanghoang/Category.java
@@ -1,0 +1,21 @@
+package vn.id.thongdanghoang;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToOne;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+public class Category extends PanacheEntity {
+    public String name;
+
+    @ManyToMany(mappedBy = "categories")
+    public Set<Product> products = new HashSet<>();
+
+    @OneToOne
+    @JoinColumn(name = "parent_id")
+    public Category parent;
+}

--- a/src/main/java/vn/id/thongdanghoang/CategoryRepository.java
+++ b/src/main/java/vn/id/thongdanghoang/CategoryRepository.java
@@ -1,0 +1,8 @@
+package vn.id.thongdanghoang;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CategoryRepository implements PanacheRepository<Category> {
+}

--- a/src/main/java/vn/id/thongdanghoang/Product.java
+++ b/src/main/java/vn/id/thongdanghoang/Product.java
@@ -1,0 +1,27 @@
+package vn.id.thongdanghoang;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+public class Product extends PanacheEntity {
+    public String name;
+
+    @ManyToMany
+    @JoinTable(name = "product_category",
+        joinColumns = @JoinColumn(name = "product_id"),
+        inverseJoinColumns = @JoinColumn(name = "category_id"))
+    public Set<Category> categories = new HashSet<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<Variant> variants = new ArrayList<>();
+}

--- a/src/main/java/vn/id/thongdanghoang/ProductRepository.java
+++ b/src/main/java/vn/id/thongdanghoang/ProductRepository.java
@@ -1,0 +1,8 @@
+package vn.id.thongdanghoang;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ProductRepository implements PanacheRepository<Product> {
+}

--- a/src/main/java/vn/id/thongdanghoang/Variant.java
+++ b/src/main/java/vn/id/thongdanghoang/Variant.java
@@ -1,0 +1,15 @@
+package vn.id.thongdanghoang;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Variant extends PanacheEntity {
+    public String name;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    public Product product;
+}

--- a/src/main/java/vn/id/thongdanghoang/VariantRepository.java
+++ b/src/main/java/vn/id/thongdanghoang/VariantRepository.java
@@ -1,0 +1,8 @@
+package vn.id.thongdanghoang;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class VariantRepository implements PanacheRepository<Variant> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,26 @@
 greeting:
   message: "hello"
+
+"%dev":
+  quarkus:
+    datasource:
+      db-kind: h2
+      jdbc:
+        url: jdbc:h2:mem:design-dev;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+      username: sa
+      password: sa
+    hibernate-orm:
+      database:
+        generation: drop-and-create
+
+"%test":
+  quarkus:
+    datasource:
+      db-kind: h2
+      jdbc:
+        url: jdbc:h2:mem:design-test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+      username: sa
+      password: sa
+    hibernate-orm:
+      database:
+        generation: drop-and-create

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,6 +1,10 @@
--- This file allow to write SQL commands that will be emitted in test and dev.
--- The commands are commented as their support depends of the database
--- insert into myentity (id, field) values(1, 'field-1');
--- insert into myentity (id, field) values(2, 'field-2');
--- insert into myentity (id, field) values(3, 'field-3');
--- alter sequence myentity_seq restart with 4;
+-- Sample data for dev and test
+insert into category (id, name) values (1, 'Electronics');
+insert into category (id, name, parent_id) values (2, 'Phones', 1);
+insert into product (id, name) values (1, 'Smartphone');
+insert into product_category (product_id, category_id) values (1, 2);
+insert into variant (id, name, product_id) values (1, 'Smartphone 128GB', 1);
+
+alter sequence category_seq restart with 3;
+alter sequence product_seq restart with 2;
+alter sequence variant_seq restart with 2;

--- a/src/test/java/vn/id/thongdanghoang/ProductPersistenceTest.java
+++ b/src/test/java/vn/id/thongdanghoang/ProductPersistenceTest.java
@@ -1,0 +1,36 @@
+package vn.id.thongdanghoang;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashSet;
+
+@QuarkusTest
+public class ProductPersistenceTest {
+
+    @Test
+    @Transactional
+    void persistProductVariantAndCategory() {
+        Category category = new Category();
+        category.name = "Electronics";
+        category.persist();
+
+        Product product = new Product();
+        product.name = "Phone";
+        product.categories = new HashSet<>();
+        product.categories.add(category);
+        product.persist();
+
+        Variant variant = new Variant();
+        variant.name = "Phone 64GB";
+        variant.product = product;
+        variant.persist();
+
+        assertEquals(1, Product.count());
+        assertEquals(1, Variant.count());
+        assertEquals(1, Category.count());
+    }
+}


### PR DESCRIPTION
## Summary
- configure H2 datasource for dev and test environments
- model Product, Variant and Category with JPA relationships
- seed sample data and add basic persistence test

## Testing
- `./gradlew test` *(fails: Could not resolve io.quarkus:quarkus-junit5:3.26.1 - Received status code 403 from server: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b56fa7864083318256c9efd929d5f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced product catalog entities: Products, Categories (with parent-child hierarchy), and Variants.
  * Enabled linking products to multiple categories and managing product variants.
* Chores
  * Added development and test database profiles using an in-memory database with automatic schema generation.
  * Seeded sample data for categories, products, and variants to simplify local setup.
* Tests
  * Added an integration test to verify persistence and relationships across products, categories, and variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->