### PR TITLE
Add H2 setup and sample domain entities

### DIFF
--- a/src/main/java/vn/id/thongdanghoang/model/Category.java
+++ b/src/main/java/vn/id/thongdanghoang/model/Category.java
@@ -1,0 +1,27 @@
+package vn.id.thongdanghoang.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String name;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    public Category parent;
+
+    @OneToMany(mappedBy = "parent")
+    public Set<Category> children = new HashSet<>();
+}

--- a/src/main/java/vn/id/thongdanghoang/model/Product.java
+++ b/src/main/java/vn/id/thongdanghoang/model/Product.java
@@ -1,0 +1,33 @@
+package vn.id.thongdanghoang.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+public class Product {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String name;
+
+    @ManyToMany
+    @JoinTable(name = "product_category",
+            joinColumns = @JoinColumn(name = "product_id"),
+            inverseJoinColumns = @JoinColumn(name = "category_id"))
+    public Set<Category> categories = new HashSet<>();
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    public List<Variant> variants = new ArrayList<>();
+}

--- a/src/main/java/vn/id/thongdanghoang/model/Variant.java
+++ b/src/main/java/vn/id/thongdanghoang/model/Variant.java
@@ -1,0 +1,21 @@
+package vn.id.thongdanghoang.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Variant {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String sku;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    public Product product;
+}

--- a/src/main/java/vn/id/thongdanghoang/repository/CategoryRepository.java
+++ b/src/main/java/vn/id/thongdanghoang/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package vn.id.thongdanghoang.repository;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import vn.id.thongdanghoang.model.Category;
+
+@ApplicationScoped
+public class CategoryRepository implements PanacheRepository<Category> {
+}
+

--- a/src/main/java/vn/id/thongdanghoang/repository/ProductRepository.java
+++ b/src/main/java/vn/id/thongdanghoang/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package vn.id.thongdanghoang.repository;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import vn.id.thongdanghoang.model.Product;
+
+@ApplicationScoped
+public class ProductRepository implements PanacheRepository<Product> {
+}
+

--- a/src/main/java/vn/id/thongdanghoang/repository/VariantRepository.java
+++ b/src/main/java/vn/id/thongdanghoang/repository/VariantRepository.java
@@ -1,0 +1,10 @@
+package vn.id.thongdanghoang.repository;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import vn.id.thongdanghoang.model.Variant;
+
+@ApplicationScoped
+public class VariantRepository implements PanacheRepository<Variant> {
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,26 @@
+"%dev":
+  quarkus:
+    datasource:
+      db-kind: h2
+      username: sa
+      password: sa
+      jdbc:
+        url: jdbc:h2:mem:dev;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    hibernate-orm:
+      database:
+        generation: drop-and-create
+
+"%test":
+  quarkus:
+    datasource:
+      db-kind: h2
+      username: sa
+      password: sa
+      jdbc:
+        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    hibernate-orm:
+      database:
+        generation: drop-and-create
+
 greeting:
   message: "hello"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,8 @@
       jdbc:
         url: jdbc:h2:mem:dev;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     hibernate-orm:
-      database:
-        generation: drop-and-create
+      schema-management:
+        strategy: drop-and-create
 
 "%test":
   quarkus:
@@ -19,8 +19,8 @@
       jdbc:
         url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     hibernate-orm:
-      database:
-        generation: drop-and-create
+      schema-management:
+        strategy: drop-and-create
 
 greeting:
   message: "hello"

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -4,3 +4,4 @@
 -- insert into myentity (id, field) values(2, 'field-2');
 -- insert into myentity (id, field) values(3, 'field-3');
 -- alter sequence myentity_seq restart with 4;
+

--- a/src/test/java/vn/id/thongdanghoang/model/ProductEntityTest.java
+++ b/src/test/java/vn/id/thongdanghoang/model/ProductEntityTest.java
@@ -1,0 +1,68 @@
+package vn.id.thongdanghoang.model;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import vn.id.thongdanghoang.repository.CategoryRepository;
+import vn.id.thongdanghoang.repository.ProductRepository;
+import vn.id.thongdanghoang.repository.VariantRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class ProductEntityTest {
+
+    @Inject
+    ProductRepository productRepository;
+
+    @Inject
+    VariantRepository variantRepository;
+
+    @Inject
+    CategoryRepository categoryRepository;
+
+    @Test
+    @Transactional
+    void testProductMappings() {
+        long initialProductCount = productRepository.count();
+        long initialVariantCount = variantRepository.count();
+        long initialCategoryCount = categoryRepository.count();
+
+        Category parent = new Category();
+        parent.name = "Electronics";
+        categoryRepository.persist(parent);
+
+        Category child = new Category();
+        child.name = "Phones";
+        child.parent = parent;
+        parent.children.add(child);
+        categoryRepository.persist(child);
+
+        Product product = new Product();
+        product.name = "Phone";
+        product.categories.add(child);
+
+        Variant variant = new Variant();
+        variant.sku = "PHONE-BLACK";
+        variant.product = product;
+        product.variants.add(variant);
+
+        productRepository.persist(product);
+
+        assertEquals(initialProductCount + 1, productRepository.count());
+        assertEquals(initialVariantCount + 1, variantRepository.count());
+        assertEquals(initialCategoryCount + 2, categoryRepository.count());
+
+        Product persisted = productRepository.findById(product.id);
+        assertNotNull(persisted);
+        assertEquals(1, persisted.categories.size());
+        assertEquals(1, persisted.variants.size());
+
+        Category persistedChild = categoryRepository.findById(child.id);
+        assertEquals(parent.id, persistedChild.parent.id);
+
+        Category persistedParent = categoryRepository.findById(parent.id);
+        assertEquals(1, persistedParent.children.size());
+    }
+}


### PR DESCRIPTION
## Summary
- configure H2 datasource for dev and test profiles
- refactor entities to use repository pattern and add repositories
- update unit test to inject repositories and account for existing data
- model categories with parent/child hierarchy using one-to-many mapping

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies; received status code 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68b56fa7864083318256c9efd929d5f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added product catalog foundation: products, variants, and hierarchical categories with bidirectional relations and multi-category support.
- Chores
  - Configured dev/test profiles to use in-memory databases with automatic schema generation.
  - Adjusted seed data initialization to avoid restarting sequence during import.
- Tests
  - Added integration test verifying persistence and relationships among products, variants, and categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->